### PR TITLE
feat: password-protected private PDFs at /b/<name>

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,19 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: "/b/:path*",
+        headers: [
+          {
+            key: "X-Robots-Tag",
+            value: "noindex, nofollow",
+          },
+          {
+            key: "Cache-Control",
+            value: "private, no-store, max-age=0",
+          },
+        ],
+      },
+      {
         source: "/:path*",
         headers: [
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^24.12.4",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
+        "@vercel/blob": "^2.4.0",
         "eslint": "^9.39.2",
         "eslint-config-next": "^16.2.6",
         "postcss": "^8.5.10",
@@ -2132,6 +2133,23 @@
         }
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2371,6 +2389,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -3991,6 +4019,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -4130,6 +4182,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -5201,7 +5260,6 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5480,6 +5538,16 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -5989,6 +6057,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -6214,6 +6295,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
+    "@vercel/blob": "^2.4.0",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.2.6",
     "postcss": "^8.5.10",

--- a/scripts/upload-private-pdf.mjs
+++ b/scripts/upload-private-pdf.mjs
@@ -1,0 +1,26 @@
+// Uploads a local PDF to Vercel Blob private storage. Run once per PDF:
+//   node --env-file=.env.local scripts/upload-private-pdf.mjs <name> <path-to.pdf>
+// The PDF then becomes available (behind the password) at /b/<name>.
+import { put } from "@vercel/blob";
+import { readFile } from "node:fs/promises";
+
+const [name, localPath] = process.argv.slice(2);
+if (!name || !localPath) {
+  throw new Error("usage: <name> <path-to.pdf>");
+}
+if (!/^[a-z0-9-]{1,64}$/i.test(name)) {
+  throw new Error("name must match [a-z0-9-]{1,64}");
+}
+
+const blob = await put(`private/${name}.pdf`, await readFile(localPath), {
+  access: "private", // requires Blob Private Storage enabled on the store
+  addRandomSuffix: false, // deterministic pathname → served at /b/<name>
+  contentType: "application/pdf",
+  token: process.env.BLOB_READ_WRITE_TOKEN,
+});
+
+console.log(`Uploaded. Available at /b/${name}`);
+console.log(`Blob url: ${blob.url}`);
+console.log(
+  "Set PRIVATE_BLOB_BASE_URL to everything before /private/... in that url.",
+);

--- a/src/app/b/[doc]/route.ts
+++ b/src/app/b/[doc]/route.ts
@@ -1,0 +1,39 @@
+// Streams a private PDF from Vercel Blob. Only reachable after src/proxy.ts has
+// authenticated the request, so no auth logic is needed here.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ doc: string }> },
+) {
+  const { doc } = await ctx.params;
+  const base = process.env.PRIVATE_BLOB_BASE_URL;
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!base || !token) {
+    return new Response("Not configured", { status: 500 });
+  }
+
+  // Restrict the name so it maps to exactly one blob (no path traversal / odd input).
+  if (!/^[a-z0-9-]{1,64}$/i.test(doc)) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const upstream = await fetch(`${base}/private/${doc}.pdf`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  if (!upstream.ok || !upstream.body) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="${doc}.pdf"`,
+      "Cache-Control": "private, no-store, max-age=0",
+      "X-Robots-Tag": "noindex, nofollow",
+    },
+  });
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,7 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/", disallow: "/b/" },
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// Gate every /b/* path at the network boundary so unauthenticated requests
+// are rejected with 401 before any function runs or a blob is fetched.
+export const config = { matcher: ["/b/:path*"] };
+
+// Length-independent comparison to avoid leaking credential length/content via timing.
+function safeEqual(a: string, b: string) {
+  const ea = new TextEncoder().encode(a);
+  const eb = new TextEncoder().encode(b);
+  let diff = ea.length ^ eb.length;
+  for (let i = 0; i < Math.max(ea.length, eb.length); i++) {
+    diff |= (ea[i] ?? 0) ^ (eb[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+function unauthorized() {
+  return new NextResponse("Authentication required", {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": 'Basic realm="Private", charset="UTF-8"',
+      "Cache-Control": "no-store",
+      "X-Robots-Tag": "noindex, nofollow",
+    },
+  });
+}
+
+export function proxy(req: NextRequest) {
+  const header = req.headers.get("authorization");
+  if (!header?.startsWith("Basic ")) return unauthorized();
+
+  let decoded = "";
+  try {
+    decoded = atob(header.slice(6));
+  } catch {
+    return unauthorized();
+  }
+
+  const sep = decoded.indexOf(":");
+  if (sep === -1) return unauthorized();
+  const user = decoded.slice(0, sep);
+  const pass = decoded.slice(sep + 1);
+
+  const expectedUser = process.env.PRIVATE_PDF_USER ?? "";
+  const expectedPass = process.env.PRIVATE_PDF_PASS ?? "";
+
+  // Evaluate both comparisons unconditionally to keep timing flat, and fail closed
+  // if the credentials are not configured in this environment.
+  const okUser = safeEqual(user, expectedUser);
+  const okPass = safeEqual(pass, expectedPass);
+  if (!expectedUser || !expectedPass || !(okUser && okPass)) {
+    return unauthorized();
+  }
+
+  return NextResponse.next();
+}


### PR DESCRIPTION
## What

Adds private, password-protected PDF hosting. Each PDF is reachable at `/b/<name>` (e.g. `/b/contract`), gated by a single HTTP Basic Auth password. The existing public "Download CV" button is untouched.

## How it works

```
GET /b/<name> → proxy.ts (edge Basic Auth)
   ├─ no/bad creds → 401 (rejected at the edge — no function, no blob fetch, no bandwidth)
   └─ ok → /b/[doc] route (Node) → fetch private blob server-side → stream as application/pdf
```

- PDFs live in **Vercel Blob private storage** — never committed to this public repo.
- Edge auth in `proxy.ts` makes anonymous floods cheap to reject (DDoS posture); Vercel platform DDoS protection covers the rest.
- `/b/*` is `noindex` (header + `robots.txt` disallow) and `no-store`.

## Files

- `src/proxy.ts` — edge Basic Auth, scoped to `/b/:path*`, fails closed if creds env unset
- `src/app/b/[doc]/route.ts` — Node route handler, streams `private/<name>.pdf` from Blob
- `next.config.ts` — `/b/:path*` noindex + no-store headers
- `src/app/robots.ts` — disallow `/b/`
- `scripts/upload-private-pdf.mjs` — one command per PDF to upload to Blob
- `@vercel/blob` added as a devDependency (only the upload script uses it)

## Required setup before merge (dashboard — only you can do these)

1. Vercel → Storage → create a **Blob** store, connect to this project (auto-adds `BLOB_READ_WRITE_TOKEN`); enable Private Storage.
2. Add env vars (Production + Preview): `PRIVATE_PDF_USER`, `PRIVATE_PDF_PASS`.
3. `vercel env pull .env.local`, then upload a PDF: `node --env-file=.env.local scripts/upload-private-pdf.mjs contract ./contract.pdf`
4. Set `PRIVATE_BLOB_BASE_URL` (the store host, before `/private/...` from the printed blob url) in Vercel + `.env.local`.

## Verified locally

- `npm run lint` + `npm run build` pass
- `/b/test` with no creds → `401` + `WWW-Authenticate` + `noindex`; bad creds → `401`
- `robots.txt` contains `Disallow: /b/`
- Public CV (`/assets/cv_ivo_santiago.pdf`) and homepage unaffected

Full 200/PDF-stream path needs the Blob store + env vars above — testable on this PR's Vercel **preview** deploy once they're set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)